### PR TITLE
ci: disable Conform GPG identity verification

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -9,8 +9,8 @@ policies:
       dco: true
       gpg:
         required: true
-        identity:
-          gitHubOrganization: supernetes
+#        identity:
+#          gitHubOrganization: supernetes
       spellcheck:
         locale: US
       maximumOfOneCommit: true


### PR DESCRIPTION
GitHub's generated merge commits are signed with GitHub's key, which does not seem to be bound to any user that could be added to the organization, resulting in identity check fails. This check can be re-enabled when either support for external GPG keys is added to Conform or, alternatively, the merge process can be allocated to a merge bot that can be directly added to the organization (this is now it's done in Talos).