### PR TITLE
feat: use `-trimpath` for truncating source file paths in binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,11 @@ _docker-%:
 %.pb.go %_grpc.pb.go: %.proto
 	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative $*.proto
 
+# Trim build directory and GOPATH from paths registered in built binaries
+go_flags := "all=-trimpath=$(shell pwd);$(GOPATH)"
+
 _client _server: _%: api/supernetes.pb.go
-	go install -C ./$* -ldflags "-X 'github.com/supernetes/supernetes/common/pkg/log.buildDir=$(shell pwd)'"
+	go install -C ./$* -gcflags $(go_flags) -asmflags $(go_flags)
 
 _proto: $(patsubst %.proto,%.pb.go,$(wildcard api/*.proto))
 

--- a/common/pkg/log/log.go
+++ b/common/pkg/log/log.go
@@ -8,15 +8,10 @@ package log
 
 import (
 	"os"
-	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/rs/zerolog"
 )
-
-// To be populated at build time
-var buildDir string
 
 // Main logger instance
 var logger *zerolog.Logger
@@ -24,15 +19,6 @@ var logger *zerolog.Logger
 func Init(level zerolog.Level) {
 	if logger != nil {
 		Panic().Msg("logger re-initialization is forbidden")
-	}
-
-	zerolog.CallerMarshalFunc = func(pc uintptr, file string, line int) string {
-		// If buildDir was set, attempt to canonicalize file paths for IDEs
-		if relFile, err := filepath.Rel(buildDir, file); err == nil {
-			file = relFile
-		}
-
-		return file + ":" + strconv.Itoa(line)
 	}
 
 	l := zerolog.New(


### PR DESCRIPTION
This is a much smarter and faster solution compared to relativizing path references on every `zerolog` invocation. Additional benefits: also applies to panic logs, and doesn't leak details about build environment.