### PR TITLE
ci: add workflow for building binaries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,16 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+name: Build
+jobs:
+  build:
+    name: Binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v4
+      - name: Run make
+        run: make


### PR DESCRIPTION
This is just for verifying that the project remains buildable as part of the required CI checks. Container image packaging and downloadable artifacts will come later.