### PR TITLE
docs: update README nomenclature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Supernetes is an HPC bridge for your Kubernetes environment: Expose your HPC nod
 
 ## Building
 
-The build system requires (rootless) `docker` (or Podman symlinked to `docker`) and `make` to be present on your system. To build the client and server binaries, simply run
+The build system requires (rootless) `docker` (or Podman symlinked to `docker`) and `make` to be present on your system. To build the controller and agent binaries, simply run
 
 ```shell
-make client server
+make
 ```
 
 To clean up any build artifacts, run

--- a/controller/pkg/endpoint/endpoint.go
+++ b/controller/pkg/endpoint/endpoint.go
@@ -61,6 +61,10 @@ func Serve(config *config.Controller) (Endpoint, error) {
 
 	// TODO: Multitenancy, this will round-robin through all reverse tunnels. Use handler.KeyAsChannel()
 	//  instead with an AffinityKey function above to scope it to only clients of a particular HPC environment
+
+	// TODO: Potentially, if Cilium is able to do TLS termination and apply L7 logic to gRPC traffic, we could
+	//  also just route different agents (HPC environments) to different controller instances -> better scalability
+
 	srv.client = api.NewAgentClient(srv.handler.AsChannel())
 
 	// Register reverse tunnel handler to a server that the agents can connect to


### PR DESCRIPTION
Instructions should now match the changes of https://github.com/supernetes/supernetes/pull/10.