### PR TITLE
ci: fetch tags for all `make` operations

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - name: Check out sources
         uses: actions/checkout@v4
+        with:
+          # https://github.com/actions/checkout/issues/1471#issuecomment-1755639487
+          fetch-depth: 0
+          filter: tree:0
       - name: Use Docker in rootless mode
         uses: ScribeMD/rootless-docker@0.2.2
       - name: Cache Docker volumes

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -33,6 +33,10 @@ jobs:
     steps:
       - name: Check out sources
         uses: actions/checkout@v4
+        with:
+          # https://github.com/actions/checkout/issues/1471#issuecomment-1755639487
+          fetch-depth: 0
+          filter: tree:0
       - name: Run make tidy
         run: make tidy
       - name: Check changed files
@@ -76,6 +80,10 @@ jobs:
     steps:
       - name: Check out sources
         uses: actions/checkout@v4
+        with:
+          # https://github.com/actions/checkout/issues/1471#issuecomment-1755639487
+          fetch-depth: 0
+          filter: tree:0
       - name: Compile protobuf artifacts
         run: make proto
       - name: Run golangci-lint

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,9 @@ jobs:
       - name: Check out sources
         uses: actions/checkout@v4
         with:
+          # https://github.com/actions/checkout/issues/1471#issuecomment-1755639487
           fetch-depth: 0
+          filter: tree:0
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Image tagging in the Makefile relies on Git tags being present, and Git will complain with `fatal: No names found, cannot describe anything.` for all targets if they are absent.