### PR TITLE
feat: implement K8s RBAC for the controller

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - manifest/controller.yaml
   - manifest/namespace.yaml
+  - manifest/rbac.yaml

--- a/deploy/manifest/controller.yaml
+++ b/deploy/manifest/controller.yaml
@@ -23,3 +23,4 @@ spec:
                 - ALL
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+      serviceAccountName: supernetes

--- a/deploy/manifest/rbac.yaml
+++ b/deploy/manifest/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: supernetes
+  namespace: supernetes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: patch-kube-proxy
+  namespace: kube-system
+rules:
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    resourceNames: ["kube-proxy"]
+    verbs: ["patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: patch-kube-proxy
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: patch-kube-proxy
+subjects:
+  - kind: ServiceAccount
+    name: supernetes
+    namespace: supernetes

--- a/src/controller/pkg/vk/proxy.go
+++ b/src/controller/pkg/vk/proxy.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/supernetes/supernetes/common/pkg/log"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -26,6 +27,11 @@ func DisableKubeProxy(k8sClient kubernetes.Interface) error {
 		[]byte("{\"spec\":{\"template\":{\"spec\":{\"affinity\":{\"nodeAffinity\":{\"requiredDuringSchedulingIgnoredDuringExecution\":{\"nodeSelectorTerms\":[{\"matchExpressions\":[{\"key\":\"type\",\"operator\":\"NotIn\",\"values\":[\"virtual-kubelet\"]}]}]}}}}}}}"),
 		metav1.PatchOptions{},
 	)
+
+	if apierrors.IsNotFound(err) {
+		log.Debug().Msg("kube-proxy DaemonSet not deployed, ignoring")
+		return nil
+	}
 
 	return errors.Wrap(err, "patching kube-proxy DaemonSet failed")
 }


### PR DESCRIPTION
Special privileges are required, for example, to patch the `kube-proxy` DaemonSet. Using a dedicated ServiceAccount also helps in restricting unnecessary permissions.