### PR TITLE
feat: secure agent-to-controller communication with TLS

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - manifest/controller.yaml
   - manifest/namespace.yaml
   - manifest/rbac.yaml
+  - manifest/route.yaml
+  - manifest/service.yaml

--- a/deploy/manifest/route.yaml
+++ b/deploy/manifest/route.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: supernetes
+  namespace: supernetes
+spec:
+  parentRefs:
+    - name: supernetes
+      sectionName: grpc
+  rules:
+    - backendRefs:
+        - name: supernetes
+          port: 40404

--- a/deploy/manifest/service.yaml
+++ b/deploy/manifest/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: supernetes
+  namespace: supernetes
+spec:
+  selector:
+    app: supernetes
+  ports:
+    - name: supernetes-api
+      protocol: TCP
+      port: 40404
+      targetPort: 40404

--- a/src/controller/go.mod
+++ b/src/controller/go.mod
@@ -3,6 +3,7 @@ module github.com/supernetes/supernetes/controller
 go 1.22.3
 
 require (
+	github.com/fullstorydev/grpchan v1.1.1
 	github.com/jhump/grpctunnel v0.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
@@ -32,7 +33,6 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/fullstorydev/grpchan v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect


### PR DESCRIPTION
Provides initial support for the agent to use TLS to connect to the controller's API endpoint in the Kubernetes cluster. Supernetes will deploy [Gateway API](https://gateway-api.sigs.k8s.io/) manifests, which assumes that the Gateway API CRDs are present in the cluster. The cluster should also provide a "supernetes" Gateway to utilize the provided routes. This work does NOT yet implement client authentication (thus, no mTLS).