### PR TITLE
feat: start Virtual Kubelet instances asynchronously

### DIFF
--- a/deploy/manifest/rbac.yaml
+++ b/deploy/manifest/rbac.yaml
@@ -35,7 +35,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: patch-kube-proxy
+  name: supernetes-kube-proxy
   namespace: kube-system
 rules:
   - apiGroups: ["apps"]
@@ -46,12 +46,36 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: patch-kube-proxy
+  name: supernetes-kube-proxy
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: patch-kube-proxy
+  name: supernetes-kube-proxy
+subjects:
+  - kind: ServiceAccount
+    name: supernetes
+    namespace: supernetes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: supernetes-node-lease
+  namespace: kube-node-lease
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: supernetes-node-lease
+  namespace: kube-node-lease
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: supernetes-node-lease
 subjects:
   - kind: ServiceAccount
     name: supernetes

--- a/src/controller/main.go
+++ b/src/controller/main.go
@@ -57,14 +57,14 @@ func main() {
 
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(10 * time.Second)
 
 	k8sClient, err := client.NewK8sClient()
 	log.FatalErr(err).Msg("failed to create K8s client")
 
 	log.FatalErr(vk.DisableKubeProxy(k8sClient)).Msg("disabling kube-proxy for Virtual Kubelet nodes failed")
 
-	manager := controller.NewManager(k8sClient)
+	manager := controller.NewManager(context.Background(), k8sClient)
 
 done:
 	for {

--- a/src/controller/pkg/client/client.go
+++ b/src/controller/pkg/client/client.go
@@ -30,6 +30,10 @@ func NewK8sClient() (kubernetes.Interface, error) {
 		}
 	}
 
+	// TODO: These need to be configurable
+	kubecfg.QPS = 100 * rest.DefaultQPS
+	kubecfg.Burst = 100 * rest.DefaultBurst
+
 	k8sClient, err := kubernetes.NewForConfig(kubecfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating K8s client failed: %v", err)


### PR DESCRIPTION
The controller bottlenecks heavily on waiting for pod and node controllers to become ready serially. This needs to be faster for processing thousands of nodes.