### PR TITLE
feat: initial node info gathering support for agent

### DIFF
--- a/src/agent/go.mod
+++ b/src/agent/go.mod
@@ -3,14 +3,15 @@ module github.com/supernetes/supernetes/agent
 go 1.23.1
 
 require (
-	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	github.com/jhump/grpctunnel v0.3.0
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/supernetes/supernetes/api v0.0.0
 	github.com/supernetes/supernetes/config v0.0.0
 	github.com/supernetes/supernetes/util v0.0.0
 	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.2
+	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd
 )
 
 require (
@@ -37,7 +38,6 @@ require (
 	k8s.io/apimachinery v0.31.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
-	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/src/agent/go.sum
+++ b/src/agent/go.sum
@@ -48,8 +48,6 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e h1:XmA6L9IPRdUr28a+SK/oMchGgQy159wvzXA5tJ7l+40=
-github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e/go.mod h1:AFIo+02s+12CEg8Gzz9kzhCbmbq6JcKNrhHffCGA9z4=
 github.com/jhump/gopoet v0.0.0-20190322174617-17282ff210b3/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/gopoet v0.1.0/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/goprotoc v0.5.0/go.mod h1:VrbvcYrQOrTi3i0Vf+m+oqQWk9l72mjkJCYo7UvLHRQ=
@@ -78,6 +76,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/src/agent/main.go
+++ b/src/agent/main.go
@@ -29,6 +29,14 @@ var (
 	configPath string
 )
 
+/*
+TODO: Slurm node discovery and workload dispatching
+ - scontrol show partition [standard] --json
+ - scontrol show node --json
+ - sinfo -N --json (but this produces much more output without that much more information)
+ - Helpful tool: https://mholt.github.io/json-to-go/
+*/
+
 func main() {
 	// TODO: Implement full CLI with Cobra in `cmd`?
 	pflag.StringVarP(&configPath, "config", "c", "", "path to agent configuration file (mandatory)")
@@ -59,7 +67,7 @@ func main() {
 
 	// Register services for reverse tunnels
 	tunnelServer := grpctunnel.NewReverseTunnelServer(tunnelpb.NewTunnelServiceClient(conn))
-	agentServer := server.NewServer(1, 0.1)
+	agentServer := server.NewServer()
 	api.RegisterNodeApiServer(tunnelServer, agentServer)
 
 	controllerDone := make(chan struct{})

--- a/src/agent/pkg/scontrol/common.go
+++ b/src/agent/pkg/scontrol/common.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package scontrol
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"sigs.k8s.io/json"
+)
+
+// Number represents a numeric value type in the `scontrol` JSON output
+type Number struct {
+	Set      bool `json:"set"`
+	Infinite bool `json:"infinite"`
+	Number   int  `json:"number"`
+}
+
+// run executes an `scontrol` command with the given arguments, returning JSON bytes
+func run(args ...string) ([]byte, error) {
+	cmd := exec.Command("scontrol", append([]string{"--json"}, args...)...)
+	return cmd.Output()
+}
+
+// decode decodes a configuration struct from the given JSON bytes
+func decode[T any](input []byte) (*T, error) {
+	var config T
+	strictErrs, unmarshalErr := json.UnmarshalStrict(input, &config)
+
+	if strictErrs != nil || unmarshalErr != nil {
+		return nil, errors.Join(append([]error{
+			fmt.Errorf("unable to decode JSON input into %T", config),
+			unmarshalErr}, strictErrs...)...)
+	}
+
+	return &config, nil
+}

--- a/src/agent/pkg/scontrol/node_info.go
+++ b/src/agent/pkg/scontrol/node_info.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package scontrol
+
+type NodeInfo struct {
+	Meta     Meta   `json:"meta"`
+	Nodes    []Node `json:"nodes"`
+	Warnings []any  `json:"warnings"`
+	Errors   []any  `json:"errors"`
+}
+
+type Plugins struct {
+	DataParser        string `json:"data_parser"`
+	AccountingStorage string `json:"accounting_storage"`
+}
+
+type Version struct {
+	Major int `json:"major"`
+	Micro int `json:"micro"`
+	Minor int `json:"minor"`
+}
+
+type Slurm struct {
+	Version Version `json:"version"`
+	Release string  `json:"release"`
+}
+
+type Meta struct {
+	Plugins Plugins  `json:"plugins"`
+	Command []string `json:"command"`
+	Slurm   Slurm    `json:"Slurm"`
+}
+
+type Energy struct {
+	AverageWatts           int    `json:"average_watts"`
+	BaseConsumedEnergy     int    `json:"base_consumed_energy"`
+	ConsumedEnergy         int    `json:"consumed_energy"`
+	CurrentWatts           Number `json:"current_watts"`
+	PreviousConsumedEnergy int    `json:"previous_consumed_energy"`
+	LastCollected          int    `json:"last_collected"`
+}
+
+type ExternalSensors struct {
+	ConsumedEnergy   Number `json:"consumed_energy"`
+	Temperature      Number `json:"temperature"`
+	EnergyUpdateTime int    `json:"energy_update_time"`
+	CurrentWatts     int    `json:"current_watts"`
+}
+
+type Power struct {
+	MaximumWatts    Number `json:"maximum_watts"`
+	CurrentWatts    int    `json:"current_watts"`
+	TotalEnergy     int    `json:"total_energy"`
+	NewMaximumWatts int    `json:"new_maximum_watts"`
+	PeakWatts       int    `json:"peak_watts"`
+	LowestWatts     int    `json:"lowest_watts"`
+	NewJobTime      int    `json:"new_job_time"`
+	State           int    `json:"state"`
+	TimeStartDay    int    `json:"time_start_day"`
+}
+
+type Node struct {
+	Architecture              string          `json:"architecture"`
+	BurstbufferNetworkAddress string          `json:"burstbuffer_network_address"`
+	Boards                    int             `json:"boards"`
+	BootTime                  int             `json:"boot_time"`
+	ClusterName               string          `json:"cluster_name"`
+	Cores                     int             `json:"cores"`
+	SpecializedCores          int             `json:"specialized_cores"`
+	CPUBinding                int             `json:"cpu_binding"`
+	CPULoad                   Number          `json:"cpu_load"`
+	FreeMem                   Number          `json:"free_mem"`
+	Cpus                      int             `json:"cpus"`
+	EffectiveCpus             int             `json:"effective_cpus"`
+	SpecializedCpus           string          `json:"specialized_cpus"`
+	Energy                    Energy          `json:"energy"`
+	ExternalSensors           ExternalSensors `json:"external_sensors"`
+	Extra                     string          `json:"extra"`
+	Power                     Power           `json:"power"`
+	Features                  []string        `json:"features"`
+	ActiveFeatures            []string        `json:"active_features"`
+	Gres                      string          `json:"gres"`
+	GresDrained               string          `json:"gres_drained"`
+	GresUsed                  string          `json:"gres_used"`
+	LastBusy                  int             `json:"last_busy"`
+	McsLabel                  string          `json:"mcs_label"`
+	SpecializedMemory         int             `json:"specialized_memory"`
+	Name                      string          `json:"name"`
+	NextStateAfterReboot      []string        `json:"next_state_after_reboot"`
+	Address                   string          `json:"address"`
+	Hostname                  string          `json:"hostname"`
+	State                     []string        `json:"state"`
+	OperatingSystem           string          `json:"operating_system"`
+	Owner                     string          `json:"owner"`
+	Partitions                []string        `json:"partitions"`
+	Port                      int             `json:"port"`
+	RealMemory                int             `json:"real_memory"`
+	Comment                   string          `json:"comment"`
+	Reason                    string          `json:"reason"`
+	ReasonChangedAt           int             `json:"reason_changed_at"`
+	ReasonSetByUser           string          `json:"reason_set_by_user"`
+	ResumeAfter               Number          `json:"resume_after"`
+	Reservation               string          `json:"reservation"`
+	AllocMemory               int             `json:"alloc_memory"`
+	AllocCpus                 int             `json:"alloc_cpus"`
+	AllocIdleCpus             int             `json:"alloc_idle_cpus"`
+	TresUsed                  string          `json:"tres_used"`
+	TresWeighted              float64         `json:"tres_weighted"`
+	SlurmdStartTime           int             `json:"slurmd_start_time"`
+	Sockets                   int             `json:"sockets"`
+	Threads                   int             `json:"threads"`
+	TemporaryDisk             int             `json:"temporary_disk"`
+	Weight                    int             `json:"weight"`
+	Tres                      string          `json:"tres"`
+	Version                   string          `json:"version"`
+}

--- a/src/agent/pkg/scontrol/scontrol.go
+++ b/src/agent/pkg/scontrol/scontrol.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package scontrol
+
+func ReadNodeInfo() (*NodeInfo, error) {
+	nodeInfoBytes, err := run("show", "node")
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Also handle the error field in the JSON
+	return decode[NodeInfo](nodeInfoBytes)
+}


### PR DESCRIPTION
Initial work to make the dummy agent functional. Implements `scontrol` support for the agent to discover node info that can be sent back to the controller.