### PR TITLE
ci: set up Buildkit runtime with caching, cache conform build

### DIFF
--- a/.github/actions/runtime/action.yaml
+++ b/.github/actions/runtime/action.yaml
@@ -1,0 +1,21 @@
+name: Build environment runtime
+description: Rootless Docker runtime with Buildkit
+runs:
+  using: composite
+  steps:
+    - name: Cache Docker volumes
+      uses: actions/cache@v4
+      with:
+        path: ~/.local/share/docker/volumes
+        key: docker-volumes-${{ runner.arch }}-${{ hashFiles('src/**') }}
+        restore-keys: docker-volumes-${{ runner.arch }}
+    - name: Use Docker in rootless mode
+      uses: ScribeMD/rootless-docker@0.2.2
+    - name: Set up Buildkit
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver-opts: default-load=true
+        buildkitd-flags: "" # This does not currently work, see https://github.com/docker/setup-buildx-action/pull/363
+        install: true # docker build == docker buildx build
+    - name: Expose GitHub runtime # Required for GitHub Actions caching with Buildkit
+      uses: crazy-max/ghaction-github-runtime@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ name: Build
 jobs:
   build:
     name: Binaries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out sources
         uses: actions/checkout@v4
@@ -16,12 +16,7 @@ jobs:
           # https://github.com/actions/checkout/issues/1471#issuecomment-1755639487
           fetch-depth: 0
           filter: tree:0
-      - name: Use Docker in rootless mode
-        uses: ScribeMD/rootless-docker@0.2.2
-      - name: Cache Docker volumes
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/share/docker/volumes
-          key: docker-volumes-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
+      - name: Set up runtime
+        uses: ./.github/actions/runtime
       - name: Run make
         run: make

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -8,7 +8,7 @@ name: Check
 jobs:
   conform:
     name: Conformance
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: golang:1
       options: --user 1001 # https://github.com/actions/runner/issues/2033#issuecomment-1598547465
@@ -18,6 +18,17 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+      - name: Get date
+        id: get-date
+        run: echo "date=$(date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+      - name: Cache Golang resources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            /go/pkg/mod
+          key: conform-${{ runner.arch }}-${{ steps.get-date.outputs.date }}
+          restore-keys: conform-${{ runner.arch }}
       - name: Fetch master branch for reference
         # The main branch detection of siderolabs/conform relies on the branch tracking the "origin" remote, see
         # https://github.com/siderolabs/conform/blob/2feadaa74eef93dd35f303582f2e82afa62a119d/cmd/conform/enforce.go#L74
@@ -29,7 +40,7 @@ jobs:
         run: conform enforce
   tidy:
     name: Module Tidiness
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out sources
         uses: actions/checkout@v4
@@ -37,13 +48,8 @@ jobs:
           # https://github.com/actions/checkout/issues/1471#issuecomment-1755639487
           fetch-depth: 0
           filter: tree:0
-      - name: Use Docker in rootless mode
-        uses: ScribeMD/rootless-docker@0.2.2
-      - name: Cache Docker volumes
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/share/docker/volumes
-          key: docker-volumes-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
+      - name: Set up runtime
+        uses: ./.github/actions/runtime
       - name: Run make tidy
         run: make tidy
       - name: Check changed files
@@ -66,7 +72,7 @@ jobs:
   # It's 2024 and https://github.com/golangci/golangci-lint/issues/828 has still not been resolved
   resolve-modules:
     name: Resolve Modules
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -80,7 +86,7 @@ jobs:
   golangci:
     name: Linting
     needs: resolve-modules
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix: ${{ fromJson(needs.resolve-modules.outputs.matrix) }}
       fail-fast: false
@@ -91,13 +97,8 @@ jobs:
           # https://github.com/actions/checkout/issues/1471#issuecomment-1755639487
           fetch-depth: 0
           filter: tree:0
-      - name: Use Docker in rootless mode
-        uses: ScribeMD/rootless-docker@0.2.2
-      - name: Cache Docker volumes
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/share/docker/volumes
-          key: docker-volumes-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
+      - name: Set up runtime
+        uses: ./.github/actions/runtime
       - name: Compile protobuf artifacts
         run: make proto
       - name: Run golangci-lint

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -8,7 +8,7 @@ name: Cleanup
 jobs:
   cleanup:
     name: Configuration
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.ref_type != 'tag' # Ignore tags for now
     env:
       BRANCH_NAME: ${{ github.event.ref || format('pull-{0}', github.event.number) }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,7 @@ name: Deploy
 jobs:
   image:
     name: Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       digest: ${{ steps.digest.outputs.digest }}
     permissions:
@@ -26,13 +26,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Use Docker in rootless mode
-        uses: ScribeMD/rootless-docker@0.2.2
-      - name: Cache Docker volumes
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/share/docker/volumes
-          key: docker-volumes-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
+      - name: Set up runtime
+        uses: ./.github/actions/runtime
       - name: Build and push image
         run: make image-push
       - name: Retrieve image digest
@@ -40,7 +35,7 @@ jobs:
         id: digest
   config:
     name: Configuration
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: image
     env:
       BRANCH_NAME: ${{ (github.head_ref && format('pull-{0}', github.event.number)) || github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 all: agent controller config
 
+c := ,
 _docker: # Force target for pattern rule phony
 _docker-%: _docker
-	docker build -t supernetes-build .
+	docker build -t supernetes-build . $(if $(strip $(CI)),--cache-to type=gha$(c)mode=max --cache-from type=gha,)
 	docker run --rm --init $(if $(strip $(CI)),,-it) \
 		-e CGO_ENABLED=0 \
 		-e GOBIN=/build/bin \


### PR DESCRIPTION
Also migrates from `ubuntu-latest` to `ubuntu-22.04` to avoid issues with the new `kernel.apparmor_restrict_unprivileged_userns=1` option (which can't be easily disabled in GH actions): https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15