### PR TITLE
ci: allow GH Actions to push to the container registry

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
       - name: Set up runtime
         uses: ./.github/actions/runtime
       - name: Build and push image


### PR DESCRIPTION
The automatic CI/CD pipeline for PRs requires Actions runs from forks to still be able to push to GHCR. This is [disallowed](https://github.com/orgs/community/discussions/69331#discussioncomment-7206091) by default, with the only workaround being a PAT (classic). For this to be safe, each workflow run must be manually inspected and triggered by an organization member (which they already are), so hopefully the fork Actions can now use the secret.