### PR TITLE
ci: configure environment for deployment

### DIFF
--- a/.github/workflows/approve.yaml
+++ b/.github/workflows/approve.yaml
@@ -1,0 +1,21 @@
+# This is a dummy workflow that depends on the Deploy environment,
+# it's used to require manual approval on privileged workflow runs
+
+# SECURITY: This can permit PRs from forks to run potentially malicious
+# deployments, it's important for these jobs to be configured to always
+# require maintainer review and manual approval before running.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+name: Approve
+jobs:
+  approve:
+    name: Privileged
+    environment: approved
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Privileged workflows approved"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,14 +1,16 @@
 on:
-  pull_request:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows:
+      - Approve
+    types:
+      - completed
 
 name: Deploy
 jobs:
   image:
     name: Image
     runs-on: ubuntu-22.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       digest: ${{ steps.digest.outputs.digest }}
     permissions:
@@ -25,7 +27,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up runtime
         uses: ./.github/actions/runtime
       - name: Build and push image
@@ -36,6 +38,7 @@ jobs:
   config:
     name: Configuration
     runs-on: ubuntu-22.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     needs: image
     env:
       BRANCH_NAME: ${{ (github.head_ref && format('pull-{0}', github.event.number)) || github.ref_name }}


### PR DESCRIPTION
Deployment to the container registry from PRs from forks can't be done with`pull_request` due to lack of secret access. We can work around this by triggering `workflow_run`, which runs with the target repo's privileges. To avoid a security risk, introduce an additional dummy "Approve" workflow, which requires explicitly approved access to an environment.