### PR TITLE
ci: third attempt of a sane deployment workflow for forks

### DIFF
--- a/.github/actions/deploy-configuration/action.yaml
+++ b/.github/actions/deploy-configuration/action.yaml
@@ -1,0 +1,37 @@
+name: Deploy configuration
+description: Update the deployment repository with a new configuration
+inputs:
+  digest:
+    description: Digest of built image
+    required: true
+  branch:
+    description: Deploy repository branch to update
+    required: true
+    default: ${{ (github.head_ref && format('pull-{0}', github.event.number)) || github.ref_name }}
+runs:
+  using: composite
+  steps:
+    - name: Prepare deployment repository
+      run: >
+        cd deploy && git checkout "${{ inputs.branch }}" ||
+        { git checkout -b "${{ inputs.branch }}" && git reset --hard "$(git rev-list --max-parents=0 HEAD)"; }
+      shell: sh
+    - name: Update deployment repository
+      run: |
+        rsync -a supernetes/deploy/ deploy/ && cd deploy
+        kustomize edit set image "${{ inputs.digest }}"
+        envsubst < ../supernetes/deploy/README.md > README.md
+      shell: sh
+    - name: Configure Git
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global push.autoSetupRemote true
+      shell: sh
+    - name: Push a new commit
+      run: |
+        cd deploy
+        git add -A
+        git commit -m "release: update controller image to ${{ inputs.digest }}"
+        git push -f
+      shell: sh

--- a/.github/actions/deploy-image/action.yaml
+++ b/.github/actions/deploy-image/action.yaml
@@ -1,0 +1,28 @@
+name: Deploy image
+description: Builds and pushes the controller container image
+inputs:
+  ghcr-password:
+    description: Password for GHCR login
+    required: true
+outputs:
+  digest:
+    description: Digest of built image
+    value: ${{ steps.digest.outputs.digest }}
+runs:
+  using: composite
+  steps:
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.ghcr-password }}
+    - name: Set up runtime
+      uses: ./supernetes/.github/actions/runtime
+    - name: Build and push image
+      run: cd supernetes && make image-push
+      shell: sh
+    - name: Retrieve image digest
+      id: digest
+      run: cd supernetes && echo "digest=$(make image-digest)" >> "$GITHUB_OUTPUT"
+      shell: sh

--- a/.github/workflows/approve.yaml
+++ b/.github/workflows/approve.yaml
@@ -1,0 +1,22 @@
+# This is a helper for automating the approval of the deployment jobs if the actor (triggering user) is trusted. This
+# should avoid the need for constantly clicking around manual approvals. Supernetes maintainers should first add
+# themselves to the required reviewers of the "deploy" environment, then to the `actor_allow_list` below.
+
+on:
+  deployment:
+  workflow_dispatch:
+
+name: Approve
+jobs:
+  approve:
+    name: Deployments
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Auto-approve deployments
+        uses: activescott/automate-environment-deployment-approval@main
+        with:
+          github_token: ${{ secrets.REGISTRY_TOKEN }}
+          environment_allow_list: |
+            deploy
+          actor_allow_list: |
+            twelho

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,7 @@
 on:
-  # SECURITY: This can permit PRs from forks to run potentially malicious pushes to the registry.
-  # This is safe only if these jobs are configured to always require maintainer review and manual
-  # approval before running. The manual approval requirement is established through the
-  # "approved" environment.
+  # SECURITY: This can permit PRs from forks to run potentially malicious pushes to the registry. This is safe only if
+  # these jobs are configured to always require maintainer review and manual approval before running. The manual
+  # approval requirement is established through the "deploy" environment.
   pull_request_target:
   push:
     branches:
@@ -10,12 +9,10 @@ on:
 
 name: Deploy
 jobs:
-  image:
-    name: Image
+  controller:
+    name: Controller
     runs-on: ubuntu-22.04
-    environment: approved
-    outputs:
-      digest: ${{ steps.digest.outputs.digest }}
+    environment: deploy
     permissions:
       packages: write
     steps:
@@ -25,55 +22,20 @@ jobs:
           # https://github.com/actions/checkout/issues/1471#issuecomment-1755639487
           fetch-depth: 0
           filter: tree:0
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up runtime
-        uses: ./.github/actions/runtime
-      - name: Build and push image
-        run: make image-push
-      - name: Retrieve image digest
-        run: echo "digest=$(make image-digest)" >> "$GITHUB_OUTPUT"
-        id: digest
-  config:
-    name: Configuration
-    runs-on: ubuntu-22.04
-    environment: approved
-    needs: image
-    env:
-      BRANCH_NAME: ${{ (github.head_ref && format('pull-{0}', github.event.number)) || github.ref_name }}
-    steps:
-      - name: Check out sources
-        uses: actions/checkout@v4
-        with:
           path: supernetes
+      - name: Deploy image
+        id: image
+        uses: ./supernetes/.github/actions/deploy-image
+        with:
+          ghcr-password: ${{ secrets.GITHUB_TOKEN }}
       - name: Check out deployment repository
         uses: actions/checkout@v4
         with:
           repository: supernetes/deploy
-          path: deploy
           fetch-depth: 0
+          path: deploy
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-      - name: Prepare deployment repository
-        run: >
-          cd deploy && git checkout "$BRANCH_NAME" ||
-          { git checkout -b "$BRANCH_NAME" && git reset --hard "$(git rev-list --max-parents=0 HEAD)"; }
-      - name: Update deployment repository
-        run: |
-          rsync -a supernetes/deploy/ deploy/ && cd deploy
-          kustomize edit set image "${{ needs.image.outputs.digest }}"
-          envsubst < ../supernetes/deploy/README.md > README.md
-      - name: Configure Git
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global push.autoSetupRemote true
-      - name: Push a new commit
-        run: |
-          cd deploy
-          git add -A
-          git commit -m "release: update controller image to ${{ needs.image.outputs.digest }}"
-          git push -f
+      - name: Deploy configuration
+        uses: ./supernetes/.github/actions/deploy-configuration
+        with:
+          digest: ${{ steps.image.outputs.digest }}


### PR DESCRIPTION
`environment: approved` requires manual approval for every execution on every branch/PR, which is highly inconvenient. Bundle the entire deployment workflow into two composite actions so that we can have a separate job for PRs from forks, which should now only require one approval in total.