### PR TITLE
ci: add a run ID filter to the auto-approval action

### DIFF
--- a/.github/workflows/approve.yaml
+++ b/.github/workflows/approve.yaml
@@ -3,8 +3,11 @@
 # themselves to the required reviewers of the "deploy" environment, then to the `actor_allow_list` below.
 
 on:
-  deployment:
   workflow_dispatch:
+    inputs:
+      run-id:
+        description: Workflow run ID to approve
+        required: true
 
 name: Approve
 jobs:
@@ -15,8 +18,9 @@ jobs:
       - name: Auto-approve deployments
         uses: activescott/automate-environment-deployment-approval@main
         with:
-          github_token: ${{ secrets.REGISTRY_TOKEN }}
           environment_allow_list: |
             deploy
           actor_allow_list: |
             twelho
+          run_id_allow_list: ${{ inputs.run-id }}
+          github_token: ${{ secrets.REGISTRY_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,11 @@ on:
 
 name: Deploy
 jobs:
+  approve:
+    name: Auto-approval
+    uses: ./.github/workflows/approve.yaml
+    with:
+      run-id: ${{ github.run_id }}
   controller:
     name: Controller
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Implemented in https://github.com/activescott/automate-environment-deployment-approval/pull/63, this can be used to prevent the auto-approval action from one PR approving all other pending deployments in other PRs as well.