### PR TITLE
ci: fix the auto-approval workflow event trigger

### DIFF
--- a/.github/workflows/approve.yaml
+++ b/.github/workflows/approve.yaml
@@ -3,11 +3,12 @@
 # themselves to the required reviewers of the "deploy" environment, then to the `actor_allow_list` below.
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       run-id:
         description: Workflow run ID to approve
         required: true
+        type: number
 
 name: Approve
 jobs:


### PR DESCRIPTION
This needs to be [`workflow_call`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_call) in order to be callable from another workflow.