### PR TITLE
ci: fix the `run-id` type in the auto-approval workflow event trigger

### DIFF
--- a/.github/workflows/approve.yaml
+++ b/.github/workflows/approve.yaml
@@ -8,7 +8,7 @@ on:
       run-id:
         description: Workflow run ID to approve
         required: true
-        type: number
+        type: string
 
 name: Approve
 jobs:


### PR DESCRIPTION
Try to mitigate the `Unexpected value` error.