### PR TITLE
ci: auto-approval: fix passing PAT through `workflow_call`

### DIFF
--- a/.github/workflows/approve.yaml
+++ b/.github/workflows/approve.yaml
@@ -5,14 +5,14 @@
 on:
   workflow_call:
     inputs:
-      token:
-        description: Personal Access Token (PAT) with 'repo' scope
-        required: true
-        type: string
       run-id:
         description: Workflow run ID to approve
         required: true
         type: string
+    secrets:
+      token:
+        description: Personal Access Token (PAT) with 'repo' scope
+        required: true
 
 name: Approve
 jobs:
@@ -28,4 +28,4 @@ jobs:
           actor_allow_list: |
             twelho
           run_id_allow_list: ${{ inputs.run-id }}
-          github_token: ${{ inputs.token }}
+          github_token: ${{ secrets.token }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,8 +13,9 @@ jobs:
     name: Approve
     uses: ./.github/workflows/approve.yaml
     with:
-      token: ${{ secrets.GITHUB_TOKEN }}
       run-id: ${{ github.run_id }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
   controller:
     name: Controller
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Secrets must be passed through special [`secrets` inputs](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow).