### PR TITLE
ci: auto-approval: use a fine-grained PAT

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ jobs:
     with:
       run-id: ${{ github.run_id }}
     secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.AUTO_APPROVE_TOKEN }}
   controller:
     name: Controller
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This fine-grained PAT should have the [required privileges](https://github.com/activescott/automate-environment-deployment-approval?tab=readme-ov-file#1-create-a-personal-access-token) for the auto-approve action to do its job.