### PR TITLE
ci: refine wording of `deploy-image` action description

### DIFF
--- a/.github/actions/deploy-image/action.yaml
+++ b/.github/actions/deploy-image/action.yaml
@@ -1,5 +1,5 @@
 name: Deploy image
-description: Builds and pushes the controller container image
+description: Build and push the controller container image
 inputs:
   password:
     description: Password for GHCR login


### PR DESCRIPTION
Also serves as a sanity check whether the Actions access control is now finally working as intended.