### PR TITLE
ci: check out PR in deployment Action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Check out sources
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           # https://github.com/actions/checkout/issues/1471#issuecomment-1755639487
           fetch-depth: 0
           filter: tree:0


### PR DESCRIPTION
`pull_request_target` by default checks out the master branch instead of the PR in `actions/checkout`, we need to explicitly instruct it to check out the right thing.