### PR TITLE
feat: attempt at implementing CPU and memory metrics for nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Finally, the controller also observes any Pods that users deploy directly to its
 - [x] Container image packaging with GHCR
 - [x] Kustomization for continuous deployment
 - [ ] Per-workload Slurm partition selection (https://github.com/supernetes/supernetes/issues/32)
-- [ ] Metrics support for Virtual Kubelet nodes (https://github.com/supernetes/supernetes/issues/33)
+- [x] Metrics support for Virtual Kubelet nodes
 - [x] Log retrieval/streaming support for tracked workloads
 - [ ] Complete node state reconciliation (https://github.com/supernetes/supernetes/issues/35)
 

--- a/src/agent/pkg/node/data.go
+++ b/src/agent/pkg/node/data.go
@@ -81,7 +81,7 @@ type Node struct {
 	InstanceType              string          `json:"instance_type,omitempty"` // Absent on LUMI, present on Mahti
 	LastBusy                  scontrol.Number `json:"last_busy"`               // Integer on LUMI, scontrol.Number on Mahti
 	McsLabel                  string          `json:"mcs_label"`
-	SpecializedMemory         int             `json:"specialized_memory"`
+	SpecializedMemory         int64           `json:"specialized_memory"`
 	Name                      string          `json:"name"`
 	NextStateAfterReboot      []string        `json:"next_state_after_reboot"`
 	Address                   string          `json:"address"`
@@ -90,15 +90,15 @@ type Node struct {
 	OperatingSystem           string          `json:"operating_system"`
 	Owner                     string          `json:"owner"`
 	Partitions                []string        `json:"partitions"`
-	Port                      int             `json:"port"`
-	RealMemory                int             `json:"real_memory"`
+	Port                      int32           `json:"port"`
+	RealMemory                int64           `json:"real_memory"`
 	Comment                   string          `json:"comment"`
 	Reason                    string          `json:"reason"`
 	ReasonChangedAt           scontrol.Number `json:"reason_changed_at"` // Integer on LUMI, scontrol.Number on Mahti
 	ReasonSetByUser           string          `json:"reason_set_by_user"`
 	ResumeAfter               scontrol.Number `json:"resume_after"`
 	Reservation               string          `json:"reservation"`
-	AllocMemory               int             `json:"alloc_memory"`
+	AllocMemory               int64           `json:"alloc_memory"`
 	AllocCpus                 int             `json:"alloc_cpus"`
 	AllocIdleCpus             int             `json:"alloc_idle_cpus"`
 	TresUsed                  string          `json:"tres_used"`

--- a/src/agent/pkg/scontrol/parsing.go
+++ b/src/agent/pkg/scontrol/parsing.go
@@ -41,6 +41,24 @@ func (n *Number) UnmarshalJSON(bytes []byte) error {
 	return nil
 }
 
+// ToFloat converts the special number type to a regular float
+func (n *Number) ToFloat() float32 {
+	if !n.Set {
+		return float32(math.NaN())
+	}
+
+	if n.Infinite {
+		negative := 1
+		if n.Number < 0 {
+			negative = -1
+		}
+
+		return float32(math.Inf(negative))
+	}
+
+	return n.Number
+}
+
 // Compile-time type checking
 var _ json.Unmarshaler = &Version{}
 

--- a/src/api/v1alpha1/node.proto
+++ b/src/api/v1alpha1/node.proto
@@ -24,11 +24,18 @@ message NodeMeta {
 
 // Data description for workloads, similar to .spec in Kubernetes resource definitions
 message NodeSpec {
-  // TODO: CPUs etc.
+  uint32 cpu_count = 1;
+  uint64 mem_bytes = 2;
+}
+
+message NodeStatus {
+  float cpu_load = 1; // Linux load average
+  uint64 ws_bytes = 2; // Memory usage in bytes (working set)
 }
 
 // Node describes the properties of a single node in the HPC environment
 message Node {
   NodeMeta meta = 1;
   NodeSpec spec = 2;
+  NodeStatus status = 3;
 }

--- a/src/controller/pkg/node/reconciler.go
+++ b/src/controller/pkg/node/reconciler.go
@@ -137,8 +137,8 @@ func (r *nReconciler) Reconcile(ctx context.Context) error {
 
 		if i, ok := r.instances[node.Meta.Name]; ok {
 			// Existing node, still tracked
-			// TODO: Need to check here whether the node actually still exists as a resource. If not, the most atomic
-			//  way to get it back is to re-create the instance.
+			// TODO: Need to check here whether the node actually still exists as a resource.
+			//  If not, the most atomic way to get it back is to re-create the instance.
 			i.tracked = true
 		} else {
 			// New node, create a new instance for it
@@ -151,6 +151,9 @@ func (r *nReconciler) Reconcile(ctx context.Context) error {
 				VkAuth:         r.vkAuth,
 			}))
 		}
+
+		// Update the status of the node
+		r.instances[node.Meta.Name].instance.UpdateNodeStatus(node.Status)
 	}
 
 	// Start/stop tracked/untracked instances

--- a/src/controller/pkg/provider/handler.go
+++ b/src/controller/pkg/provider/handler.go
@@ -243,18 +243,17 @@ func (p *podProvider) GetStatsSummary(context.Context) (*statsv1alpha1.Summary, 
 // GetMetricsResource gets the metrics for the node, including running pods
 func (p *podProvider) GetMetricsResource(context.Context) ([]*dto.MetricFamily, error) {
 	// TODO: This is verbose, disable logging for now
-	//sulog.Trace().Msg("GetMetricsResource stub")
+	//sulog.Trace().Msg("GetMetricsResource called")
+
+	// For Metrics Server, the metrics this needs to report are here:
+	//  https://github.com/kubernetes-sigs/metrics-server/blob/029dfa4e03b0f01b3ec4000ee25030e40511823f/pkg/scraper/client/resource/decode.go#L33-L34
+	//	- node_cpu_usage_seconds_total, which is an integral of cpu-seconds
+	//	- node_memory_working_set_bytes, which is the total working set memory usage on the node
+	// Helpful command for debugging:
+	//  kubectl get --raw /api/v1/nodes/<node>/proxy/metrics/resource | grep node_cpu_usage_seconds_total
 	return []*dto.MetricFamily{
-		{
-			Name: ptr.To("cpu_usage_total"),
-			Help: ptr.To("Total CPU usage"),
-			Type: dto.MetricType_COUNTER.Enum(),
-			Metric: []*dto.Metric{
-				{
-					Counter: &dto.Counter{Value: ptr.To(float64(1234))},
-				},
-			},
-		},
+		p.metricsProvider.CpuMetric(),
+		p.metricsProvider.MemMetric(),
 	}, nil
 }
 

--- a/src/controller/pkg/provider/metrics.go
+++ b/src/controller/pkg/provider/metrics.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package provider
+
+import (
+	"sync"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	api "github.com/supernetes/supernetes/api/v1alpha1"
+	"k8s.io/utils/ptr"
+)
+
+// MetricsProvider implements the necessary node metrics for Metrics Server. Details here:
+// https://github.com/kubernetes-sigs/metrics-server/blob/029dfa4e03b0f01b3ec4000ee25030e40511823f/pkg/scraper/client/resource/decode.go#L33-L34
+type MetricsProvider interface {
+	Update(status *api.NodeStatus) // Update the metrics based on the given status
+	CpuMetric() *dto.MetricFamily  // Get the `node_cpu_usage_seconds_total` metric
+	MemMetric() *dto.MetricFamily  // Get the `node_memory_working_set_bytes` metric
+}
+
+type metricsProvider struct {
+	mutex       sync.Mutex
+	coreSeconds float64
+	workingSet  float64
+	timestamp   time.Time
+	loadAvg     float32
+}
+
+func NewMetricsProvider() MetricsProvider {
+	return &metricsProvider{}
+}
+
+func (m *metricsProvider) Update(status *api.NodeStatus) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	now := time.Now()
+	diff := now.Sub(m.timestamp)
+
+	// Integrate core seconds
+	m.coreSeconds += float64(m.loadAvg) * diff.Seconds()
+	m.workingSet = float64(status.WsBytes)
+
+	m.timestamp = now
+	m.loadAvg = status.CpuLoad
+}
+
+func (m *metricsProvider) CpuMetric() *dto.MetricFamily {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return &dto.MetricFamily{
+		Name: ptr.To("node_cpu_usage_seconds_total"),
+		Help: ptr.To("Cumulative cpu time consumed by the node in core-seconds"),
+		Type: dto.MetricType_COUNTER.Enum(),
+		Metric: []*dto.Metric{
+			{
+				Counter:     &dto.Counter{Value: ptr.To(m.coreSeconds)},
+				TimestampMs: ptr.To(m.timestamp.UnixMilli()),
+			},
+		},
+	}
+}
+
+func (m *metricsProvider) MemMetric() *dto.MetricFamily {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return &dto.MetricFamily{
+		Name: ptr.To("node_memory_working_set_bytes"),
+		Help: ptr.To("Current working set of the node in bytes"),
+		Type: dto.MetricType_GAUGE.Enum(),
+		Metric: []*dto.Metric{
+			{
+				Gauge:       &dto.Gauge{Value: ptr.To(m.workingSet)},
+				TimestampMs: ptr.To(m.timestamp.UnixMilli()),
+			},
+		},
+	}
+}

--- a/src/controller/pkg/provider/provider.go
+++ b/src/controller/pkg/provider/provider.go
@@ -34,24 +34,26 @@ type PodProvider interface {
 
 // podProvider implements the Virtual Kubelet pod lifecycle handler for Supernetes workloads
 type podProvider struct {
-	log            *zerolog.Logger
-	pods           map[podKey]*corev1.Pod
-	pendingStatus  map[podKey]*corev1.PodStatus
-	nodeName       string
-	workloadClient api.WorkloadApiClient
-	tracker        tracker.Tracker
-	notifier       func(*corev1.Pod)
-	mutex          sync.Mutex
+	log             *zerolog.Logger
+	pods            map[podKey]*corev1.Pod
+	pendingStatus   map[podKey]*corev1.PodStatus
+	nodeName        string
+	workloadClient  api.WorkloadApiClient
+	tracker         tracker.Tracker
+	metricsProvider MetricsProvider
+	notifier        func(*corev1.Pod)
+	mutex           sync.Mutex
 }
 
-func NewPodProvider(log *zerolog.Logger, nodeName string, workloadClient api.WorkloadApiClient, tracker tracker.Tracker) PodProvider {
+func NewPodProvider(log *zerolog.Logger, nodeName string, workloadClient api.WorkloadApiClient, tracker tracker.Tracker, metricsProvider MetricsProvider) PodProvider {
 	return &podProvider{
-		log:            log,
-		pods:           make(map[podKey]*corev1.Pod),
-		pendingStatus:  make(map[podKey]*corev1.PodStatus),
-		nodeName:       nodeName,
-		workloadClient: workloadClient,
-		tracker:        tracker,
+		log:             log,
+		pods:            make(map[podKey]*corev1.Pod),
+		pendingStatus:   make(map[podKey]*corev1.PodStatus),
+		nodeName:        nodeName,
+		workloadClient:  workloadClient,
+		tracker:         tracker,
+		metricsProvider: metricsProvider,
 	}
 }
 


### PR DESCRIPTION
This implements the two key node metrics, `node_cpu_usage_seconds_total` and `node_memory_working_set_bytes`, in order to try to get some basic observability going through Metrics Server. If this works, we should see the CPU and memory columns in K9s get populated, for example. Slurm exposes only very coarse load averages and lacks a way to retrieve the working set in terms of node memory usage, so take these metrics with a grain of salt.

Fixes https://github.com/supernetes/supernetes/issues/33.