### PR TITLE
ci: fix cleanup workflow, correctly set ref in deployment README

### DIFF
--- a/.github/actions/deploy-configuration/action.yaml
+++ b/.github/actions/deploy-configuration/action.yaml
@@ -21,6 +21,8 @@ runs:
         rsync -a supernetes/deploy/ deploy/ && cd deploy
         kustomize edit set image "${{ inputs.digest }}"
         envsubst < ../supernetes/deploy/README.md > README.md
+      env:
+        BRANCH_NAME: ${{ inputs.branch }}
       shell: sh
     - name: Configure Git
       run: |

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event.ref_type != 'tag' # Ignore tags for now
     env:
-      BRANCH_NAME: ${{ github.event.ref || format('pull-{0}', github.event.number) }}
+      BRANCH_NAME: ${{ (github.head_ref && format('pull-{0}', github.event.number)) || github.ref_name }}
     steps:
       - name: Check out deployment repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This should fix stale branches being left behind by the cleanup workflow, and the Kustomize ref being blank in the README of the deployment repo.