### PR TITLE
feat: implement configuration for node/workload reconciliation intervals

### DIFF
--- a/src/config/cmd/generate.go
+++ b/src/config/cmd/generate.go
@@ -7,6 +7,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/lithammer/dedent"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -38,6 +40,8 @@ func NewCmdGenerate() *cobra.Command {
 			        --controller-port 12345 \
 			        --controller-secret-name custom-supernetes-config \
 			        --controller-secret-namespace custom-supernetes-namespace \
+					--reconcile-nodes 10s \
+					--reconcile-workloads 10s \
 			        --slurm-account project_123456789 \
 			        --slurm-partition standard \
 			        --filter-partition '^(?:standard)|(?:bench)$' \
@@ -64,6 +68,9 @@ func addGenerateFlags(fs *pflag.FlagSet, flags *run.GenerateFlags) {
 	fs.BoolVarP(&flags.ControllerSecret, "controller-secret", "s", true, "output controller configuration as a Kubernetes Secret")
 	fs.StringVar(&flags.ControllerSecretName, "controller-secret-name", "supernetes-config", "name of the controller configuration Secret")
 	fs.StringVar(&flags.ControllerSecretNamespace, "controller-secret-namespace", "supernetes", "namespace of the controller configuration Secret")
+
+	fs.DurationVar(&flags.NodeReconciliationInterval, "reconcile-nodes", time.Minute, "node reconciliation interval")
+	fs.DurationVar(&flags.WorkloadReconciliationInterval, "reconcile-workloads", time.Minute, "workload reconciliation interval")
 
 	fs.StringVar(&flags.SlurmAccount, "slurm-account", "", "default Slurm partition to use for dispatching jobs")
 	fs.StringVar(&flags.SlurmPartition, "slurm-partition", "", "default Slurm partition to use for dispatching jobs")

--- a/src/config/pkg/config/common.go
+++ b/src/config/pkg/config/common.go
@@ -22,6 +22,7 @@ type MTlsConfig struct {
 }
 
 // Decode a configuration struct from the given YAML bytes
+// TODO: This should validate the configuration as well
 func Decode[T any](input []byte) (*T, error) {
 	var config T
 	if err := yaml.UnmarshalStrict(input, &config); err != nil {

--- a/src/config/pkg/config/controller.go
+++ b/src/config/pkg/config/controller.go
@@ -7,6 +7,8 @@
 package config
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -14,8 +16,14 @@ import (
 // ControllerConfig encapsulates all relevant configuration for deploying a controller
 // TODO: Versioning
 type ControllerConfig struct {
-	Port       uint16     `json:"port"`       // Port that the controller binds to
-	MTlsConfig MTlsConfig `json:"mTLSConfig"` // mTLS configuration for the controller
+	Port       uint16          `json:"port"`       // Port that the controller binds to
+	MTlsConfig MTlsConfig      `json:"mTLSConfig"` // mTLS configuration for the controller
+	Reconcile  ReconcileConfig `json:"reconcile"`  // Reconciliation configuration
+}
+
+type ReconcileConfig struct {
+	NodeInterval     time.Duration `json:"nodeInterval"`     // Node reconciliation interval
+	WorkloadInterval time.Duration `json:"workloadInterval"` // Workload reconciliation interval
 }
 
 // ToSecret converts the ControllerConfig into a corev1.Secret

--- a/src/config/pkg/run/generate.go
+++ b/src/config/pkg/run/generate.go
@@ -38,6 +38,9 @@ type GenerateOptions struct {
 	ControllerSecretName      string
 	ControllerSecretNamespace string
 
+	NodeReconciliationInterval     time.Duration
+	WorkloadReconciliationInterval time.Duration
+
 	SlurmAccount   string
 	SlurmPartition string
 
@@ -96,6 +99,10 @@ func Generate(g *GenerateOptions) error {
 	controllerConfig := &config.ControllerConfig{
 		Port:       g.ControllerPort,
 		MTlsConfig: *controllerMTls,
+		Reconcile: config.ReconcileConfig{
+			NodeInterval:     g.NodeReconciliationInterval,
+			WorkloadInterval: g.WorkloadReconciliationInterval,
+		},
 	}
 
 	log.Debug().Msg("encoding controller configuration")

--- a/src/controller/main.go
+++ b/src/controller/main.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/supernetes/supernetes/common/pkg/log"
@@ -68,7 +67,7 @@ func main() {
 
 	workloadTracker := tracker.New()
 	nodeReconciler, err := node.NewReconciler(ctx, node.ReconcilerConfig{
-		Interval:       10 * time.Second,
+		Interval:       config.Reconcile.NodeInterval,
 		NodeClient:     ep.Node(),
 		WorkloadClient: ep.Workload(),
 		Tracker:        workloadTracker,
@@ -77,7 +76,7 @@ func main() {
 	})
 	log.FatalErr(err).Msg("failed to create node reconciler")
 	workloadReconciler, err := workload.NewReconciler(ctx, workload.ReconcilerConfig{
-		Interval:      10 * time.Second,
+		Interval:      config.Reconcile.WorkloadInterval,
 		Client:        ep.Workload(),
 		KubeConfig:    kubeConfig,
 		StatusUpdater: nodeReconciler,


### PR DESCRIPTION
Thus far these options have been hard-coded to semi-short values, which might cause issues especially with Slurm setups that aren't configured to support heavy scraping. Now there are some options in the configuration system, with 1 minute sane defaults. The values are currently validated quite deep, a proper configuration validation framework is in order at some point.