### PR TITLE
ci: enable Dependabot for Go

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directories:
+      - src/*
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
Dependabot is a bit more limited compared to Renovate, but it's easier to maintain. Some co-dependent packages, such as ones under the k8s.io umbrella, might need to be upgraded atomically, so some additional group configuration may be necessary if this doesn't work right away.