### PR TITLE
ci: switch from Dependabot to Renovate

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directories:
-      - src/*
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"

--- a/.github/renovate-custom.json5
+++ b/.github/renovate-custom.json5
@@ -1,0 +1,39 @@
+// `preUpdateOptions` or similar doesn't exist: https://github.com/renovatebot/renovate/discussions/35466
+
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended"],
+    "repositories": ["supernetes/supernetes"],
+    "enabledManagers": ["gomod", "github-actions"],
+    "packageRules": [
+        {
+            "matchManagers": ["github-actions"],
+            "groupName": "CI/CD system"
+        },
+        {
+            "matchManagers": ["gomod"],
+            "matchFileNames": ["src/agent/**"],
+            "groupName": "dependencies of `agent`"
+        },
+        {
+            "matchManagers": ["gomod"],
+            "matchFileNames": ["src/api/**"],
+            "groupName": "dependencies of `api`"
+        },
+        {
+            "matchManagers": ["gomod"],
+            "matchFileNames": ["src/controller/**"],
+            "groupName": "dependencies of `controller`"
+        },
+        {
+            "matchManagers": ["gomod"],
+            "matchFileNames": ["src/config/**"],
+            "groupName": "dependencies of `config`"
+        },
+        {
+            "matchManagers": ["gomod"],
+            "matchFileNames": ["src/common/**"],
+            "groupName": "dependencies of `common`"
+        }
+    ]
+}

--- a/.github/renovate-entrypoint.sh
+++ b/.github/renovate-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -ex
+
+echo "Command: $0"
+echo "Args: $1"
+echo "Args: $2"
+echo "Args: $3"
+echo "Args: $4"
+echo "Args: $5"
+
+pwd
+
+ls
+
+sleep 60
+
+#runuser -u ubuntu renovate

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,32 @@
+# The strategy here might be to override the entrypoint (using `docker-cmd-file`) and run `make proto` from there before
+# the actual entrypoint. This should be possible, since `make` is present in the Renovate container, and there's an
+# option to pass the Docker socket into the container as well (`mount-docker-socket` and `docker-socket-host-path`),
+# enabling the containerized build system to run protoc. In any case, Dependabot won't cut it here.
+
+#on:
+#  schedule:
+#    - cron: "0 0 * * 1" # Every Monday
+
+on:
+  pull_request:
+
+name: Renovate
+jobs:
+  renovate:
+    name: Dependencies
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v4
+      - name: Use Docker in rootless mode
+        uses: ScribeMD/rootless-docker@0.2.2
+      - name: Run Renovate
+        uses: renovatebot/github-action@v43.0.8
+        with:
+          configurationFile: .github/renovate-custom.json5
+#          docker-cmd-file: .github/renovate-entrypoint.sh
+          docker-user: root # Rootless
+#          mount-docker-socket: true
+          token: ${{ secrets.RENOVATE_TOKEN }}
+#        env:
+#          LOG_LEVEL: 'debug'


### PR DESCRIPTION
The API module contains generated code, which must be present for `go mod`. Essentially, we need a way to run `make proto` before dependency checks and upgrades can proceed. Dependabot doesn't support this, so we're left with [Renovate](https://github.com/renovatebot/renovate), which runs as a GitHub Action. However, it still runs within its own Docker container, which means we need to do some tricks: the container image contains `make`, and we can pass in the Docker socket to be able to run `make proto` (thanks to requiring minimal host dependencies). To actually run `make proto` before `renovate`, we can use the officially supported command override.