### PR TITLE
ci: switch from Dependabot to Renovate

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directories:
-      - src/*
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"

--- a/.github/renovate-custom.json5
+++ b/.github/renovate-custom.json5
@@ -1,0 +1,52 @@
+// `preUpdateOptions` or similar doesn't exist: https://github.com/renovatebot/renovate/discussions/35466
+
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended", ":gitSignOff"],
+    "gitAuthor": "twelho (Renovate) <twelho+renovate@welho.tech>",
+    "onboarding": false, // Self-hosted Renovate
+    "requireConfig": "optional", // Self-hosted Renovate
+    "repositories": ["supernetes/supernetes"],
+    "enabledManagers": ["gomod", "github-actions"],
+    "commitMessagePrefix": "chore:",
+    "commitMessageAction": "update",
+    "commitMessageLowerCase": "never",
+    "prHourlyLimit": 0,
+    "automerge": true, // Enable GitHub auto-merging for Renovate
+    "allowedCommands": ["^make .*$"],
+    "postUpgradeTasks": {
+        "commands": ["make CI=true tidy"],
+        "executionMode": "branch"
+    },
+    "packageRules": [
+        {
+            "matchManagers": ["github-actions"],
+            "groupName": "CI/CD dependencies"
+        },
+        {
+            "matchManagers": ["gomod"],
+            "matchFileNames": ["src/agent/**"],
+            "groupName": "dependencies of `agent`"
+        },
+        {
+            "matchManagers": ["gomod"],
+            "matchFileNames": ["src/api/**"],
+            "groupName": "dependencies of `api`"
+        },
+        {
+            "matchManagers": ["gomod"],
+            "matchFileNames": ["src/controller/**"],
+            "groupName": "dependencies of `controller`"
+        },
+        {
+            "matchManagers": ["gomod"],
+            "matchFileNames": ["src/config/**"],
+            "groupName": "dependencies of `config`"
+        },
+        {
+            "matchManagers": ["gomod"],
+            "matchFileNames": ["src/common/**"],
+            "groupName": "dependencies of `common`"
+        }
+    ]
+}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,31 @@
+# This is self-hosted Renovate: we can't use the Mend-hosted one, since we need to be able to run `make tidy` in
+# `postUpgradeTasks` to both generate the Protobuf artifacts and sync dependency updates across the components.
+# This remains a paid feature for the hosted version, and an absent feature in Dependabot.
+
+on:
+  schedule:
+    - cron: "0 15 * * 1" # Run a pass every Monday at 15:00
+  workflow_dispatch: # Manual invocation option
+
+name: Renovate
+jobs:
+  renovate:
+    name: Dependencies
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v4
+      - name: Use Docker in rootless mode
+        uses: ScribeMD/rootless-docker@0.2.2
+      - name: Source environment
+        run: echo XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" >> "$GITHUB_ENV"
+      - name: Run Renovate
+        uses: renovatebot/github-action@v43.0.8
+        with:
+          configurationFile: .github/renovate-custom.json5
+          docker-user: root # We're running rootless
+          mount-docker-socket: true # Required for `make tidy` inside the Renovate container
+          docker-socket-host-path: ${{ env.XDG_RUNTIME_DIR }}/docker.sock # Rootless Docker socket
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.RENOVATE_GIT_PRIVATE_KEY }}


### PR DESCRIPTION
The API module contains generated code, which must be present for `go mod`. Essentially, we need a way to run `make proto` before dependency checks and upgrades can proceed. Dependabot doesn't support this, so we're left with [Renovate](https://github.com/renovatebot/renovate), which runs as a GitHub Action. However, it still runs within its own Docker container, which means we need to do some tricks: the container image contains `make`, and we can pass in the Docker socket to be able to run `make proto` (thanks to requiring minimal host dependencies). To actually run `make proto` before `renovate`, we can use the officially supported command override.