### PR TITLE
ci: use GH Actions caching only when running in GH Actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: agent controller config
 c := ,
 _docker: # Force target for pattern rule phony
 _docker-%: _docker
-	docker build -t supernetes-build . $(if $(strip $(CI)),--cache-to type=gha$(c)mode=max --cache-from type=gha,)
+	docker build -t supernetes-build . $(if $(strip $(GITHUB_ACTIONS)),--cache-to type=gha$(c)mode=max --cache-from type=gha,)
 	docker run --rm --init $(if $(strip $(CI)),,-it) \
 		-e CGO_ENABLED=0 \
 		-e GOBIN=/build/bin \


### PR DESCRIPTION
This is in preparation for https://github.com/supernetes/supernetes/pull/81, where Renovate needs to run `make tidy` in CI mode, but can't use GH Actions caching.