### PR TITLE
meta: add `chore` type for conventional commits

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -16,6 +16,7 @@ policies:
       maximumOfOneCommit: true
       conventional:
         types:
+          - chore
           - ci
           - docs
           - meta


### PR DESCRIPTION
This type is to be used by Renovate following https://github.com/supernetes/supernetes/pull/81.