### PR TITLE
ci: switch to fork of rootless Docker Action

### DIFF
--- a/.github/actions/runtime/action.yaml
+++ b/.github/actions/runtime/action.yaml
@@ -21,7 +21,7 @@ runs:
         restore-keys: docker-volumes-${{ runner.arch }}
       if: ${{ !inputs.save-cache }}
     - name: Use Docker in rootless mode
-      uses: ScribeMD/rootless-docker@0.2.2
+      uses: AJGranowski/rootless-docker-action@23266b5b1fa508009c9ac4be4f8bde450fc3e269
     - name: Set up Buildkit
       uses: docker/setup-buildx-action@v3
       with:


### PR DESCRIPTION
Upgrading to `ubuntu-24.04` is blocked by this Action due to [AppArmor changes](https://github.com/ScribeMD/rootless-docker/issues/401). The [PR for fixing this](https://github.com/ScribeMD/rootless-docker/pull/402) is up, but upstream is dormant. However, Renovate will try the `ubuntu-24.04` upgrade immediately, so let's switch to a pinned version of the Action that carries the fix for now.