### PR TITLE
chore: don't pin versions in local `go.mod` replacements

### DIFF
--- a/src/agent/go.mod
+++ b/src/agent/go.mod
@@ -49,8 +49,8 @@ require (
 )
 
 replace (
-	github.com/supernetes/supernetes/api v0.0.0 => ../api
-	github.com/supernetes/supernetes/common v0.0.0 => ../common
-	github.com/supernetes/supernetes/config v0.0.0 => ../config
+	github.com/supernetes/supernetes/api => ../api
+	github.com/supernetes/supernetes/common => ../common
+	github.com/supernetes/supernetes/config => ../config
 	k8s.io/api => k8s.io/api v0.30.0 // k8s.io/api/resource/v1alpha2 needed by k8s.io/client-go/kubernetes/scheme
 )

--- a/src/config/go.mod
+++ b/src/config/go.mod
@@ -41,6 +41,6 @@ require (
 )
 
 replace (
-	github.com/supernetes/supernetes/common v0.0.0 => ../common
+	github.com/supernetes/supernetes/common => ../common
 	k8s.io/api => k8s.io/api v0.30.0 // k8s.io/api/resource/v1alpha2 needed by k8s.io/client-go/kubernetes/scheme
 )

--- a/src/controller/go.mod
+++ b/src/controller/go.mod
@@ -151,8 +151,8 @@ require (
 replace (
 	cloud.google.com/go => cloud.google.com/go v0.115.0 // https://github.com/grpc/grpc-go/issues/6696#issuecomment-1857815248
 	//github.com/prometheus/common => github.com/prometheus/common v0.60.1 // https://github.com/prometheus/common/pull/665 for Virtual Kubelet
-	github.com/supernetes/supernetes/api v0.0.0 => ../api
-	github.com/supernetes/supernetes/common v0.0.0 => ../common
-	github.com/supernetes/supernetes/config v0.0.0 => ../config
+	github.com/supernetes/supernetes/api => ../api
+	github.com/supernetes/supernetes/common => ../common
+	github.com/supernetes/supernetes/config => ../config
 	github.com/virtual-kubelet/virtual-kubelet => github.com/twelho/virtual-kubelet v0.0.0-20241031125312-8ddc886f6e1d
 )


### PR DESCRIPTION
Renovate uncovered an issue here where the local replacements are no longer enacted when versions get upgraded.