### PR TITLE
ci: run Renovate multiple times when scheduled

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -4,7 +4,10 @@
 
 on:
   schedule:
-    - cron: "0 15 * * 1" # Run a pass every Monday at 15:00
+    # Run passes every 15 minutes on Mondays between 15:00 and 16:00. We need to trigger this workflow
+    # multiple times, as Renovate will only auto-merge one branch/PR, per target branch, per run:
+    # https://docs.renovatebot.com/key-concepts/automerge/#renovate-automerges-take-time
+    - cron: "0/15 15 * * 1"
   workflow_dispatch: # Manual invocation option
 
 name: Renovate


### PR DESCRIPTION
Renovate will only auto-merge [one branch/PR, per target branch, per run](https://docs.renovatebot.com/key-concepts/automerge/#renovate-automerges-take-time), so we need to make sure it is executed a sufficient amount of times to merge more PRs than it creates.