### PR TITLE
chore: switch back to upstream Virtual Kubelet

### DIFF
--- a/src/controller/go.mod
+++ b/src/controller/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/supernetes/supernetes/api v0.0.0
 	github.com/supernetes/supernetes/common v0.0.0
 	github.com/supernetes/supernetes/config v0.1.0
-	github.com/virtual-kubelet/virtual-kubelet v1.11.0
+	github.com/virtual-kubelet/virtual-kubelet v1.11.1-0.20250611220432-84502b708d8f
 	google.golang.org/grpc v1.75.0
 	google.golang.org/protobuf v1.36.8
 	k8s.io/api v0.34.0
@@ -22,6 +22,7 @@ require (
 	k8s.io/apiserver v0.34.0
 	k8s.io/client-go v0.34.0
 	k8s.io/component-base v0.34.0
+	k8s.io/kubelet v0.31.4
 	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d
 	sigs.k8s.io/controller-runtime v0.22.0
 )
@@ -151,5 +152,4 @@ replace (
 	github.com/supernetes/supernetes/api => ../api
 	github.com/supernetes/supernetes/common => ../common
 	github.com/supernetes/supernetes/config => ../config
-	github.com/virtual-kubelet/virtual-kubelet => github.com/twelho/virtual-kubelet v0.0.0-20241031125312-8ddc886f6e1d
 )

--- a/src/controller/go.sum
+++ b/src/controller/go.sum
@@ -3241,8 +3241,8 @@ github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhso
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
-github.com/twelho/virtual-kubelet v0.0.0-20241031125312-8ddc886f6e1d h1:Rcry8SuDr6/oomSZ4//uOZwmxdtP7VYexxqFZDhZ8z0=
-github.com/twelho/virtual-kubelet v0.0.0-20241031125312-8ddc886f6e1d/go.mod h1:T0ATFHZx/CojgrXyd5HPM+smgkJ/sp0vqjyBdanoa0Y=
+github.com/virtual-kubelet/virtual-kubelet v1.11.1-0.20250611220432-84502b708d8f h1:L5W4TjYVBJF3i22ILdIqIAM+MYHPOpe98rFw7yM1NuI=
+github.com/virtual-kubelet/virtual-kubelet v1.11.1-0.20250611220432-84502b708d8f/go.mod h1:A3M+IT9ZW5Pf8Pew9XKbofpQyVNl20uMc11QLyZXgN0=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510 h1:S2dVYn90KE98chqDkyE9Z4N61UnQd+KOfgp5Iu53llk=
@@ -4528,6 +4528,8 @@ k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b h1:MloQ9/bdJyIu9lb1PzujOP
 k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b/go.mod h1:UZ2yyWbFTpuhSbFhv24aGNOdoRdJZgsIObGBUaYVsts=
 k8s.io/kubectl v0.34.0 h1:NcXz4TPTaUwhiX4LU+6r6udrlm0NsVnSkP3R9t0dmxs=
 k8s.io/kubectl v0.34.0/go.mod h1:bmd0W5i+HuG7/p5sqicr0Li0rR2iIhXL0oUyLF3OjR4=
+k8s.io/kubelet v0.31.4 h1:6TokbMv+HnFG7Oe9tVS/J0VPGdC4GnsQZXuZoo7Ixi8=
+k8s.io/kubelet v0.31.4/go.mod h1:8ZM5LZyANoVxUtmayUxD/nsl+6GjREo7kSanv8AoL4U=
 k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d h1:wAhiDyZ4Tdtt7e46e9M5ZSAJ/MnPGPs+Ki1gHw4w1R0=
 k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=

--- a/src/controller/pkg/provider/handler.go
+++ b/src/controller/pkg/provider/handler.go
@@ -20,9 +20,9 @@ import (
 	suerr "github.com/supernetes/supernetes/common/pkg/error"
 	sulog "github.com/supernetes/supernetes/common/pkg/log"
 	vkapi "github.com/virtual-kubelet/virtual-kubelet/node/api"
-	"github.com/virtual-kubelet/virtual-kubelet/node/api/statsv1alpha1"
 	"google.golang.org/grpc"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	statsv1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	"k8s.io/utils/ptr"
 )
 


### PR DESCRIPTION
Upstream, while unfortunately still lacking maintainers, has managed to catch up to my fork. https://github.com/virtual-kubelet/virtual-kubelet/pull/1330 remains to be merged, but it's not a blocker.